### PR TITLE
Set package author to "OSCAR team", add AUTHORS.md

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LoadFlint"
 uuid = "472f376f-f1cf-461b-9ac1-d103423be9b7"
-authors = ["Claus Fieker <fieker@mathematik.uni-kl.de>"]
+authors = ["The OSCAR team <oscar-dev@mathematik.uni-kl.de>"]
 version = "0.5.1"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Alternative approach
 Thus LoadFlint
 
 which will only make sure that libgmp and libflint are in the process space and properly initialized.
+
+## Contributors
+
+This package contains contributions by
+
+- Benjamin Lorenz
+- Claus Fieker
+- Tommy Hofmann


### PR DESCRIPTION
Alternatively, we could just drop the "authors" field from `Project.toml`. Thoughts? Having an explicit list of "authors" beyond the git history may be handy -- or annoying, as one needs to manually update it... 

In either case, I'd like to do something similar with at least Oscar.jl, GAP.jl and Singular.jl.

